### PR TITLE
Add dev/local.clj to .gitignore

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/gitignore
+++ b/lein-template/resources/leiningen/new/duct/base/gitignore
@@ -8,3 +8,4 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 /profiles.clj
+dev/local.clj


### PR DESCRIPTION
According to the [Readme](https://github.com/weavejester/duct/blob/master/README.md#file-structure), `dev/local.clj` should be kept out of version control.