### PR TITLE
Avoid uberjar classes from interfering reloading

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/project.clj
+++ b/lein-template/resources/leiningen/new/duct/base/project.clj
@@ -22,6 +22,7 @@
   :duct {:ns-prefix {{namespace}}}
   :main ^:skip-aot {{namespace}}.main{{#uberjar-name}}
   :uberjar-name "{{uberjar-name}}"{{/uberjar-name}}
+  :target-path "target/%s/"
   :aliases {"gen"   ["generate"]
             "setup" ["do" ["generate" "locals"]]{{#heroku?}}
             "deploy" ["do"


### PR DESCRIPTION
Adds ```"target/%s"``` as ```:target-path``` as suggested in https://github.com/technomancy/leiningen/blob/master/doc/PROFILES.md#activating-profiles.

Ran into this while building a small app and wondering why sometimes I get ```No namespace``` CompilerExceptions from some of my components while doing ```(reset)``` in the repl and realising that lein clean after creating an uberjar helped.