### PR TITLE
Set the prep-tasks to same as Leiningen's default value

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/project.clj
+++ b/lein-template/resources/leiningen/new/duct/base/project.clj
@@ -28,7 +28,7 @@
   :uberjar-name "{{uberjar-name}}"{{/uberjar-name}}
   :target-path "target/%s/"{{#cljs?}}
   :resource-paths ["resources" "target/cljsbuild"]
-  :prep-tasks [["cljsbuild" "once"] ["compile"]]
+  :prep-tasks [["javac"] ["cljsbuild" "once"] ["compile"]]
   :cljsbuild
   {:builds
    {:main {:jar true
@@ -44,7 +44,7 @@
   {:dev  [:project/dev  :profiles/dev]
    :test [:project/test :profiles/test]{{#cljs?}}
    :repl {:resource-paths ^:replace ["resources" "target/figwheel"]
-          :prep-tasks     ^:replace [["compile"]]}{{/cljs?}}
+          :prep-tasks     ^:replace [["javac"] ["compile"]]}{{/cljs?}}
    :uberjar {:aot :all}
    :profiles/dev  {}
    :profiles/test {}


### PR DESCRIPTION
The lack of  `javac` target in the prep-tasks makes me confused. I added `javac` target to the prep-tasks.
