### PR TITLE
Add shutdown hook for stopping system

### DIFF
--- a/duct/src/duct/util/runtime.clj
+++ b/duct/src/duct/util/runtime.clj
@@ -1,0 +1,16 @@
+(ns duct.util.runtime)
+
+(def ^:private hooks (atom {}))
+
+(defn- run-hooks []
+  (doseq [f (vals @hooks)] (f)))
+
+(defonce ^:private init-shutdown-hook
+  (delay (.addShutdownHook (Runtime/getRuntime) (Thread. #'run-hooks))))
+
+(defn add-shutdown-hook [k f]
+  (force init-shutdown-hook)
+  (swap! hooks assoc k f))
+
+(defn remove-shutdown-hook [k]
+  (swap! hooks dissoc k))

--- a/duct/test/duct/util/runtime_test.clj
+++ b/duct/test/duct/util/runtime_test.clj
@@ -1,0 +1,13 @@
+(ns duct.util.runtime-test
+  (:require [clojure.test :refer :all]
+            [duct.util.runtime :refer [add-shutdown-hook remove-shutdown-hook]]))
+
+(deftest test-add-shutdown-hook
+  (let [f #(identity true)
+        hooks (add-shutdown-hook ::foo f)]
+    (is (= f (::foo hooks)))))
+
+(deftest test-remove-shutdown-hook
+  (add-shutdown-hook ::foo #(identity true))
+  (let [hooks (remove-shutdown-hook ::foo)]
+    (is (nil? (::foo hooks)))))

--- a/lein-template/resources/leiningen/new/duct/base/main.clj
+++ b/lein-template/resources/leiningen/new/duct/base/main.clj
@@ -3,6 +3,7 @@
   (:require {{#site?}}[clojure.java.io :as io]
             {{/site?}}[com.stuartsierra.component :as component]
             [duct.middleware.errors :refer [wrap-hide-errors]]
+            [duct.util.runtime :refer [add-shutdown-hook]]
             [meta-merge.core :refer [meta-merge]]
             [{{namespace}}.config :as config]
             [{{namespace}}.system :refer [new-system]]))
@@ -19,4 +20,7 @@
 (defn -main [& args]
   (let [system (new-system config)]
     (println "Starting HTTP server on port" (-> system :http :port))
+    (add-shutdown-hook ::stop-system #(do
+                                        (println "Stopping HTTP server")
+                                        (component/stop system)))
     (component/start system)))


### PR DESCRIPTION
This patch add shutdown hook for stopping system of the component when the jvm is terminated or the program exits normally.