### PR TITLE
Support context path in wrap-route-aliases

### DIFF
--- a/duct/src/duct/middleware/route_aliases.clj
+++ b/duct/src/duct/middleware/route_aliases.clj
@@ -1,7 +1,13 @@
-(ns duct.middleware.route-aliases)
+(ns duct.middleware.route-aliases
+  (:require [ring.util.request :refer [set-context]]))
+
+(defn- update-context [request]
+  (if-let [context (:context request)]
+    (set-context request context)
+    request))
 
 (defn wrap-route-aliases [handler aliases]
   (fn [request]
     (if-let [alias (aliases (:uri request))]
-      (handler (assoc request :uri alias))
+      (handler (update-context (assoc request :uri alias)))
       (handler request))))

--- a/duct/test/duct/middleware/route_aliases_test.clj
+++ b/duct/test/duct/middleware/route_aliases_test.clj
@@ -2,11 +2,14 @@
   (:require [clojure.test :refer :all]
             [compojure.core :as compojure]
             [duct.middleware.route-aliases :refer [wrap-route-aliases]]
-            [ring.mock.request :as mock]))
+            [ring.mock.request :as mock]
+            [ring.util.request :refer [set-context]]))
 
 (deftest test-wrap-route-aliases
   (let [handler (wrap-route-aliases
                  (compojure/GET "/index.html" [] "foo")
                  {"/" "/index.html"})]
     (is (= (:body (handler (mock/request :get "/")))
-           "foo"))))
+          "foo"))
+    (is (= (:body (handler (set-context (mock/request :get "/") "")))
+          "foo"))))

--- a/duct/test/duct/middleware/route_aliases_test.clj
+++ b/duct/test/duct/middleware/route_aliases_test.clj
@@ -8,8 +8,9 @@
 (deftest test-wrap-route-aliases
   (let [handler (wrap-route-aliases
                  (compojure/GET "/index.html" [] "foo")
-                 {"/" "/index.html"})]
+                  {"/" "/index.html"
+                   "/bar" "/bar/index.html"})]
     (is (= (:body (handler (mock/request :get "/")))
           "foo"))
-    (is (= (:body (handler (set-context (mock/request :get "/") "")))
+    (is (= (:body (handler (set-context (mock/request :get "/bar") "/bar")))
           "foo"))))


### PR DESCRIPTION
`wrap-route-aliases` is not working with context path(`:context` and `:path-info` in request map).