### PR TITLE
Fix path to uberjar in ProcFile web command

### DIFF
--- a/lein-template/resources/leiningen/new/duct/heroku/Procfile
+++ b/lein-template/resources/leiningen/new/duct/heroku/Procfile
@@ -1,1 +1,1 @@
-web: java -jar target/{{uberjar-name}}
+web: java -jar target/uberjar/{{uberjar-name}}


### PR DESCRIPTION
Deploying to Heroku didn't work for me because the uberjar path didn't match the path to the jar in the ProcFile.

Can't think why this should be parameterised, so all I've done is add `uberjar` to the path. Tested and now my deploy works :)